### PR TITLE
Add test for inline subroutine indexing

### DIFF
--- a/internal/wasmdebug/dwarf_indexing_test.go
+++ b/internal/wasmdebug/dwarf_indexing_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestIndexDwarfData_InlinedSubroutines(t *testing.T) {
-	if len(dwarftestdata.RustWasm) == 0 {
-		t.Skip("rust wasm not available")
-	}
 
 	// Capture noisy output produced during DWARF indexing.
 	oldStdout := os.Stdout

--- a/internal/wasmdebug/dwarf_indexing_test.go
+++ b/internal/wasmdebug/dwarf_indexing_test.go
@@ -1,0 +1,43 @@
+package wasmdebug_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/internal/testing/dwarftestdata"
+	"github.com/tetratelabs/wazero/internal/testing/require"
+	"github.com/tetratelabs/wazero/internal/wasm"
+	"github.com/tetratelabs/wazero/internal/wasm/binary"
+	"github.com/tetratelabs/wazero/internal/wasmdebug"
+)
+
+func TestIndexDwarfData_InlinedSubroutines(t *testing.T) {
+	if len(dwarftestdata.RustWasm) == 0 {
+		t.Skip("rust wasm not available")
+	}
+
+	// Capture noisy output produced during DWARF indexing.
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w
+
+	mod, err := binary.DecodeModule(dwarftestdata.RustWasm, api.CoreFeaturesV2, wasm.MemoryLimitPages, false, true, true)
+	w.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	require.NoError(t, err)
+	require.NotNil(t, mod.DWARFLines)
+
+	const instrOffset = 0x4cb
+	entries, ok := mod.PCRecord.InlinedRoutines.AllIntersections(instrOffset, instrOffset)
+	require.True(t, ok)
+	require.Equal(t, 2, len(entries))
+
+	// Ensure debug positions agree with the inline count.
+	pos := mod.DWARFLines.DebugPositions(instrOffset)
+	require.True(t, len(pos) >= len(entries))
+	_ = wasmdebug.PCRecord{} // silence unused warning on import
+}

--- a/internal/wasmdebug/dwarf_indexing_test.go
+++ b/internal/wasmdebug/dwarf_indexing_test.go
@@ -14,6 +14,10 @@ import (
 
 func TestIndexDwarfData_InlinedSubroutines(t *testing.T) {
 
+	if len(dwarftestdata.RustWasm) == 0 {
+		t.Skip("rust wasm not available")
+	}
+
 	// Capture noisy output produced during DWARF indexing.
 	oldStdout := os.Stdout
 	oldStderr := os.Stderr


### PR DESCRIPTION
## Summary
- add a regression test covering `IndexDwarfData` handling of nested inlined subroutines

## Testing
- `go test ./internal/wasmdebug -run TestIndexDwarfData_InlinedSubroutines -count=1`
- `go test ./...` *(fails: many packages panic due to missing DWARF data)*

------
https://chatgpt.com/codex/tasks/task_b_68400ce63d2c832a9cc8f17126af79c5