### PR TITLE
ci: trust and populate Attic cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          attic-token: ${{ secrets.ATTIC_TOKEN }}
+          attic-cache: ${{ vars.ATTIC_CACHE }}
+          attic-endpoint: ${{ vars.ATTIC_ENDPOINT }}
 
       - name: Lint
         run: dev-exec just lint
@@ -89,6 +94,11 @@ jobs:
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          attic-token: ${{ secrets.ATTIC_TOKEN }}
+          attic-cache: ${{ vars.ATTIC_CACHE }}
+          attic-endpoint: ${{ vars.ATTIC_ENDPOINT }}
 
       - name: Build default package
         run: nix build .#default

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -103,6 +103,11 @@ jobs:
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
+          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
+          attic-token: ${{ secrets.ATTIC_TOKEN }}
+          attic-cache: ${{ vars.ATTIC_CACHE }}
+          attic-endpoint: ${{ vars.ATTIC_ENDPOINT }}
           siblings: |
             codetracer=${{ (github.event.inputs.codetracer_ref != 'main' && github.event.inputs.codetracer_ref) || github.event.client_payload.codetracer_ref }}
             codetracer-trace-format


### PR DESCRIPTION
## Summary
- wire recorder CI Nix setup through the Attic substituter variables
- keep the existing workflow shape and only pass cache configuration into setup-dev-env/setup-nix
- remove raw Cachix Nix setup where this repo still had it

## Validation
- parsed modified workflow YAML with yq
- ran a workflow audit confirming non-windows setup-dev-env calls pass vars.SUBSTITUTERS and vars.TRUSTED_PUBLIC_KEYS
- ran a workflow audit confirming no active owned-Cachix setup/upload references remain
