### PR TITLE
ci: run our CI on `dev` and `stable`, not just `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ name: CI
 
 on:
   push:
-    branches: [wasm-tracing, main]
+    branches: [wasm-tracing, main, dev, stable]
   pull_request:
-    branches: [wasm-tracing, main]
+    branches: [wasm-tracing, main, dev, stable]
 
 jobs:
   lint-and-test:

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -28,9 +28,9 @@ name: Cross-Repo Integration Tests
 
 on:
   pull_request:
-    branches: [wasm-tracing, main]
+    branches: [wasm-tracing, main, dev, stable]
   push:
-    branches: [wasm-tracing, main]
+    branches: [wasm-tracing, main, dev, stable]
 
   # Manual trigger with configurable codetracer revision.
   workflow_dispatch:


### PR DESCRIPTION
This repo is a **fork of `wazero/wazero`**, so it carries two kinds of
workflow. This PR touches only the two that are ours.

`main` was frozen on 2026-07-13 when the default moved to `dev`, but the
branch filters still named `main`. Both of our workflows also filter
`pull_request` on `[wasm-tracing, main]`, and PRs target `dev` — so neither
the push path nor the PR path ran. This is a **total CI blackout**.

## Evidence

| query | result |
|---|---|
| runs of `ci.yml` / `cross-repo-tests.yml` on `dev`, ever | **0** |
| last run of `ci.yml` | 2026-07-13, `push:main`, failure |
| last run of `cross-repo-tests.yml` | 2026-07-13, `push:main`, failure |
| PR bases in use | `dev`, `main`, `wasm-tracing` |

The repo looks healthy at a glance — 87 runs on `dev` — but those are all
upstream wazero workflows firing on their own triggers. They masked the fact
that **our** two workflows had gone silent.

## Change

`ci.yml` and `cross-repo-tests.yml`: `[wasm-tracing, main]` →
`[wasm-tracing, main, dev, stable]` on both `push` and `pull_request`.
`wasm-tracing` is preserved.

## Deliberately NOT touched: upstream wazero workflows

`commit.yaml`, `examples.yaml`, `integration.yaml` and `release.yaml` are
**wazero upstream's own workflows**, not ours — bare `name: Test` /
`name: Examples` / `name: Release CLI`, Go toolchain, `windows-2022`, no
reference to our runner classes or Nix. They also show 0 runs on `dev` and
match the same surface pattern, so a mechanical sweep would have rewritten
them too.

That would have been wrong. Their `main` means *upstream's* `main`, and
`release.yaml` in particular is tag-driven
(`tags: 'v[0-9]+.[0-9]+.[0-9]+**'`) with heavy `windows-2022`
pre-release builds. Repointing it at `dev` would fire a full pre-release build
on every mainline push, which nobody asked for, and would make the next
upstream merge conflict noisily.

If our fork does want upstream's Go suites running on our mainline, that is
a separate decision worth taking on its own merits.

## ⚠️ Expect red

Both workflows last concluded `failure` on 2026-07-13, and `dev` has moved a
long way since. `cross-repo-tests.yml` will be the noisier one — it builds
sibling repos that have all changed.

**Please do not revert this as a breakage.** This is a month of unchecked
merges reporting for the first time. No `continue-on-error` was added.

## Merge readiness

The `eph-*` classes are served by 8 ephemeral GARM runners which are currently
saturated. A queued check is not a passing check.

Note: `gh pr create` defaults to the **upstream** repo on a fork, so this PR
had to be targeted explicitly at `metacraft-labs/codetracer-wasm-recorder`.
Worth remembering for anyone scripting against the fork repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)